### PR TITLE
Modify Target to json loads Secret Account

### DIFF
--- a/tests/unittestcore.py
+++ b/tests/unittestcore.py
@@ -12,8 +12,7 @@ class BaseUnitTest(unittest.TestCase):
         os.environ["TARGET_BIGQUERY_STATE_FILE"] = "state.json.tmp"
         self.delete_temp_state()
 
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.normpath(
-            os.path.join(os.path.dirname(__file__), "..", "sandbox", "sa.json"))
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = json.loads(os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
 
         self.client = None
         self.project_id = None


### PR DESCRIPTION
Original Target opened the Client secrets as a file before setting it as an env variable.  With the kubernetes secrets we just need it to set it to itself.